### PR TITLE
add playback history feature

### DIFF
--- a/app/(tabs)/(index,library,search)/settings.tsx
+++ b/app/(tabs)/(index,library,search)/settings.tsx
@@ -11,6 +11,7 @@ import { SheetManager } from 'react-native-actions-sheet';
 import * as Haptics from 'expo-haptics';
 import showToast from '@lib/showToast';
 import { useEqualizer } from 'react-native-nitro-player';
+import { usePlaybackHistory } from '@lib/hooks/usePlaybackHistory';
 
 const maxBitRateOptions: SettingSelectOption[] = [
     { label: 'Original', description: 'No transcoding', value: '0', shortLabel: 'Original' },
@@ -44,7 +45,7 @@ const defaultLibraryTabOptions: SettingSelectOption[] = [
     { label: 'Songs', description: 'All songs', value: 'songs', shortLabel: 'Songs' },
 ];
 
-export type SettingId = 'streaming.maxBitRate' | 'streaming.format' | 'storage.clearCache' | 'developer.copyId' | 'ui.toastPosition' | 'ui.autoFocusSearchBar' | 'app.defaultTab' | 'app.defaultLibraryTab' | 'eq.enabled' | 'downloads.wifiOnly' | 'app.persistQueue' | 'downloads.maxBitRate' | 'downloads.format';
+export type SettingId = 'streaming.maxBitRate' | 'streaming.format' | 'storage.clearCache' | 'storage.clearHistory' | 'developer.copyId' | 'ui.toastPosition' | 'ui.autoFocusSearchBar' | 'app.defaultTab' | 'app.defaultLibraryTab' | 'eq.enabled' | 'downloads.wifiOnly' | 'app.persistQueue' | 'downloads.maxBitRate' | 'downloads.format';
 
 const EQ_PRESETS: Record<string, number[]> = {
     Flat:      [0, 0, 0, 0, 0],
@@ -185,6 +186,7 @@ export default function Settings() {
     const cache = useCache();
     const memoryCache = useMemoryCache();
     const [tabsHeight] = useTabsHeight();
+    const { clearHistory } = usePlaybackHistory();
 
     const styles = useMemo(() => StyleSheet.create({
         settings: {
@@ -296,6 +298,32 @@ export default function Settings() {
                             await showToast({
                                 title: 'Cache Cleared',
                                 subtitle: 'The cache has been cleared successfully.',
+                                icon: IconCircleCheck,
+                            });
+                        }}
+                    />
+                    <Setting
+                        id='storage.clearHistory'
+                        type='button'
+                        label='Clear Playback History'
+                        description='Remove all playback history records'
+                        onPress={async () => {
+                            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
+                            const confirmed = await SheetManager.show('confirm', {
+                                payload: {
+                                    title: 'Clear Playback History',
+                                    message: 'Are you sure you want to clear your playback history? This action cannot be undone.',
+                                    confirmText: 'Clear',
+                                    cancelText: 'Cancel',
+                                }
+                            });
+                            if (!confirmed) return;
+
+                            await clearHistory();
+
+                            await showToast({
+                                title: 'History Cleared',
+                                subtitle: 'Your playback history has been cleared successfully.',
                                 icon: IconCircleCheck,
                             });
                         }}

--- a/app/(tabs)/(library)/_layout.tsx
+++ b/app/(tabs)/(library)/_layout.tsx
@@ -5,7 +5,8 @@ export default function Layout() {
         <Stack screenOptions={{
             headerShown: false,
         }}>
-
+            <Stack.Screen name="library" />
+            <Stack.Screen name="history" />
         </Stack>
     )
 }

--- a/app/(tabs)/(library)/history.tsx
+++ b/app/(tabs)/(library)/history.tsx
@@ -1,0 +1,147 @@
+import Container from '@lib/components/Container';
+import FullscreenMessage from '@lib/components/FullscreenMessage';
+import Header from '@lib/components/Header';
+import HistoryDateSection from '@lib/components/HistoryDateSection';
+import { usePlaybackHistory, PlaybackHistoryRecord } from '@lib/hooks/usePlaybackHistory';
+import { useQueue, useTabsHeight } from '@lib/hooks';
+import { groupHistoryByDate } from '@lib/util/historyHelpers';
+import { IconHistory } from '@tabler/icons-react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { RefreshControl, SectionList, View } from 'react-native';
+import { SheetManager } from 'react-native-actions-sheet';
+import * as Haptics from 'expo-haptics';
+
+type HistorySection = {
+    title: string;
+    data: PlaybackHistoryRecord[];
+};
+
+export default function HistoryScreen() {
+    const [tabsHeight] = useTabsHeight();
+    const { fetchHistory } = usePlaybackHistory();
+    const queue = useQueue();
+
+    const [records, setRecords] = useState<PlaybackHistoryRecord[]>([]);
+    const [refreshing, setRefreshing] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [hasMore, setHasMore] = useState(true);
+
+    const loadHistory = useCallback(async (offset: number = 0, append: boolean = false) => {
+        if (loading) return;
+        setLoading(true);
+
+        try {
+            const newRecords = await fetchHistory(offset, 50);
+            
+            if (append) {
+                setRecords(prev => [...prev, ...newRecords]);
+            } else {
+                setRecords(newRecords);
+            }
+
+            setHasMore(newRecords.length === 50);
+        } catch (error) {
+            console.error('Failed to load history:', error);
+        } finally {
+            setLoading(false);
+        }
+    }, [fetchHistory, loading]);
+
+    useEffect(() => {
+        loadHistory();
+    }, []);
+
+    const handleRefresh = useCallback(async () => {
+        setRefreshing(true);
+        await loadHistory(0, false);
+        setRefreshing(false);
+    }, [loadHistory]);
+
+    const handleLoadMore = useCallback(() => {
+        if (!loading && hasMore && records.length > 0) {
+            loadHistory(records.length, true);
+        }
+    }, [loading, hasMore, records.length, loadHistory]);
+
+    const handleItemPress = useCallback(async (record: PlaybackHistoryRecord) => {
+        await queue.playTrackNow(record.trackId);
+    }, [queue]);
+
+    const handleItemLongPress = useCallback((record: PlaybackHistoryRecord) => {
+        Haptics.selectionAsync();
+        SheetManager.show('track', {
+            payload: {
+                id: record.trackId,
+                context: 'history',
+            }
+        });
+    }, []);
+
+    const sections = useMemo((): HistorySection[] => {
+        const grouped = groupHistoryByDate(records);
+        const result: HistorySection[] = [];
+
+        if (grouped.today.length > 0) {
+            result.push({ title: 'Today', data: grouped.today });
+        }
+        if (grouped.yesterday.length > 0) {
+            result.push({ title: 'Yesterday', data: grouped.yesterday });
+        }
+        if (grouped.thisWeek.length > 0) {
+            result.push({ title: 'This Week', data: grouped.thisWeek });
+        }
+        if (grouped.earlier.length > 0) {
+            result.push({ title: 'Earlier', data: grouped.earlier });
+        }
+
+        return result;
+    }, [records]);
+
+    const renderSection = useCallback(({ section }: { section: HistorySection }) => (
+        <HistoryDateSection
+            title={section.title}
+            records={section.data}
+            onItemPress={handleItemPress}
+            onItemLongPress={handleItemLongPress}
+        />
+    ), [handleItemPress, handleItemLongPress]);
+
+    const keyExtractor = useCallback((item: PlaybackHistoryRecord) => item.id.toString(), []);
+
+    const listFooter = useMemo(() => (
+        <View style={{ height: tabsHeight }} />
+    ), [tabsHeight]);
+
+    const isEmpty = records.length === 0 && !loading;
+
+    return (
+        <Container includeBottom={false}>
+            <Header title="Playback History" />
+            {isEmpty ? (
+                <View style={{ flex: 1, paddingBottom: tabsHeight }}>
+                    <FullscreenMessage
+                        icon={IconHistory}
+                        label="No playback history yet"
+                        description="Tracks you listen to will appear here"
+                    />
+                </View>
+            ) : (
+                <SectionList
+                    sections={sections}
+                    renderItem={() => null}
+                    renderSectionHeader={renderSection}
+                    keyExtractor={keyExtractor}
+                    refreshControl={
+                        <RefreshControl
+                            refreshing={refreshing}
+                            onRefresh={handleRefresh}
+                        />
+                    }
+                    onEndReached={handleLoadMore}
+                    onEndReachedThreshold={0.5}
+                    ListFooterComponent={listFooter}
+                />
+            )}
+        </Container>
+    );
+}

--- a/app/(tabs)/(library)/library.tsx
+++ b/app/(tabs)/(library)/library.tsx
@@ -4,12 +4,16 @@ import Header from '@/lib/components/Header';
 import { LibLayout, MediaLibraryLayout } from '@/lib/components/MediaLibraryList';
 import TagTabs from '@/lib/components/TagTabs';
 import { TTagTab } from '@/lib/components/TagTabs/TagTab';
-import { IconDisc, IconLayoutGrid, IconLayoutList, IconMicrophone2, IconMusic, IconPlaylist, IconPlus } from '@tabler/icons-react-native';
+import { IconDisc, IconHistory, IconLayoutGrid, IconLayoutList, IconMicrophone2, IconMusic, IconPlaylist, IconPlus } from '@tabler/icons-react-native';
 import React, { useEffect, useState } from 'react';
 import * as Haptics from 'expo-haptics';
 import { AlbumsTab, ArtistsTab, PlaylistsTab, SongsTab } from '@/lib/components/MediaLibrary';
 import { SheetManager } from 'react-native-actions-sheet';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { router } from 'expo-router';
+import { Pressable, View } from 'react-native';
+import Title from '@/lib/components/Title';
+import { useColors } from '@/lib/hooks';
 
 const tabs: TTagTab[] = [
     {
@@ -42,6 +46,7 @@ const tabs: TTagTab[] = [
 export default function Library() {
     const [tab, setTab] = useState('playlists');
     const [layout, setLayout] = useState<MediaLibraryLayout>('');
+    const colors = useColors();
 
     useEffect(() => {
         (async () => {
@@ -66,6 +71,11 @@ export default function Library() {
         })();
     }, [layout]);
 
+    const handleHistoryPress = () => {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        router.push('/history');
+    };
+
     return (
         <Container>
             <Header rightSpacing={0} title="Library" withAvatar rightSection={<>
@@ -75,6 +85,32 @@ export default function Library() {
                     setLayout(l => l == 'list' ? 'grid' : 'list');
                 }} />
             </>} />
+            <Pressable
+                onPress={handleHistoryPress}
+                style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    paddingHorizontal: 20,
+                    paddingVertical: 12,
+                    gap: 12,
+                    marginTop: 8,
+                    marginHorizontal: 20,
+                    borderRadius: 10,
+                    backgroundColor: colors.border[0],
+                }}
+            >
+                <View style={{
+                    width: 36,
+                    height: 36,
+                    borderRadius: 8,
+                    backgroundColor: colors.forcedTint + '20',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}>
+                    <IconHistory size={20} color={colors.forcedTint} />
+                </View>
+                <Title size={14} fontFamily="Poppins-Medium">Playback History</Title>
+            </Pressable>
             <TagTabs data={tabs} tab={tab} onChange={setTab} />
             <LibLayout.Provider value={layout}>
                 {tab == 'playlists' && <PlaylistsTab />}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,6 +26,7 @@ import PinsProvider from '@lib/providers/PinsProvider';
 import DownloadProvider from '@lib/providers/DownloadProvider';
 import { registerWidgetTaskHandler } from 'react-native-android-widget';
 import { widgetTaskHandler } from '@lib/widget-task-handler';
+import { PlaybackHistoryTracker } from '@lib/components/PlaybackHistoryTracker';
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
@@ -85,24 +86,26 @@ export default function RootLayout() {
             <ServerProvider>
               <SearchHistoryProvider>
                 <QueueProvider>
-                  <DownloadProvider>
-                  <MemoryCacheProvider>
-                    <PinsProvider>
-                      <GestureHandlerRootView style={{ flex: 1 }}>
-                        <SheetProvider>
-                          <Stack>
-                            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-                            <Stack.Screen name="+not-found" />
-                            <Stack.Screen name="login" options={{ headerShown: false }} />
-                            <Stack.Screen name="login-password" options={{ headerShown: false }} />
-                          </Stack>
-                          <ToastWrapper />
-                          <StatusBar style="auto" />
-                        </SheetProvider>
-                      </GestureHandlerRootView>
-                    </PinsProvider>
-                  </MemoryCacheProvider>
-                  </DownloadProvider>
+                  <PlaybackHistoryTracker>
+                    <DownloadProvider>
+                    <MemoryCacheProvider>
+                      <PinsProvider>
+                        <GestureHandlerRootView style={{ flex: 1 }}>
+                          <SheetProvider>
+                            <Stack>
+                              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+                              <Stack.Screen name="+not-found" />
+                              <Stack.Screen name="login" options={{ headerShown: false }} />
+                              <Stack.Screen name="login-password" options={{ headerShown: false }} />
+                            </Stack>
+                            <ToastWrapper />
+                            <StatusBar style="auto" />
+                          </SheetProvider>
+                        </GestureHandlerRootView>
+                      </PinsProvider>
+                    </MemoryCacheProvider>
+                    </DownloadProvider>
+                  </PlaybackHistoryTracker>
                 </QueueProvider>
               </SearchHistoryProvider>
             </ServerProvider>

--- a/lib/components/HistoryDateSection.tsx
+++ b/lib/components/HistoryDateSection.tsx
@@ -1,0 +1,49 @@
+import { useColors } from '@lib/hooks';
+import { PlaybackHistoryRecord } from '@lib/hooks/usePlaybackHistory';
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import HistoryListItem from './HistoryListItem';
+import Title from './Title';
+
+export interface HistoryDateSectionProps {
+    title: string;
+    records: PlaybackHistoryRecord[];
+    onItemPress: (record: PlaybackHistoryRecord) => void;
+    onItemLongPress: (record: PlaybackHistoryRecord) => void;
+}
+
+export default React.memo(function HistoryDateSection({ 
+    title, 
+    records, 
+    onItemPress, 
+    onItemLongPress 
+}: HistoryDateSectionProps) {
+    const colors = useColors();
+
+    const styles = useMemo(() => StyleSheet.create({
+        section: {
+            marginBottom: 10,
+        },
+        header: {
+            paddingHorizontal: 20,
+            paddingTop: 15,
+            paddingBottom: 10,
+        },
+    }), []);
+
+    return (
+        <View style={styles.section}>
+            <View style={styles.header}>
+                <Title size={18} fontFamily="Poppins-SemiBold">{title}</Title>
+            </View>
+            {records.map((record) => (
+                <HistoryListItem
+                    key={record.id}
+                    record={record}
+                    onPress={onItemPress}
+                    onLongPress={onItemLongPress}
+                />
+            ))}
+        </View>
+    );
+});

--- a/lib/components/HistoryListItem.tsx
+++ b/lib/components/HistoryListItem.tsx
@@ -1,0 +1,79 @@
+import { useColors, useCoverBuilder } from '@lib/hooks';
+import { PlaybackHistoryRecord } from '@lib/hooks/usePlaybackHistory';
+import { formatPlaybackTime } from '@lib/util/historyHelpers';
+import React, { useMemo } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import Cover from './Cover';
+import Title from './Title';
+
+export interface HistoryListItemProps {
+    record: PlaybackHistoryRecord;
+    onPress: (record: PlaybackHistoryRecord) => void;
+    onLongPress: (record: PlaybackHistoryRecord) => void;
+}
+
+export default React.memo(function HistoryListItem({ record, onPress, onLongPress }: HistoryListItemProps) {
+    const colors = useColors();
+    const cover = useCoverBuilder();
+
+    const formattedTime = useMemo(() => formatPlaybackTime(record.playedAt), [record.playedAt]);
+
+    const styles = useMemo(() => StyleSheet.create({
+        item: {
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            paddingVertical: 10,
+            paddingHorizontal: 20,
+            overflow: 'hidden',
+            gap: 10,
+        },
+        left: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 12,
+            flex: 1,
+        },
+        metadata: {
+            flex: 1,
+            overflow: 'hidden',
+        },
+        timestamp: {
+            marginTop: 2,
+        }
+    }), []);
+
+    return (
+        <Pressable
+            accessible={true}
+            accessibilityLabel={`Play ${record.title} by ${record.artist || 'Unknown Artist'}`}
+            accessibilityRole="button"
+            accessibilityHint="Double tap to play this track, long press for more options"
+            onPress={() => onPress(record)}
+            onLongPress={() => onLongPress(record)}
+        >
+            <View style={styles.item}>
+                <View style={styles.left}>
+                    <Cover
+                        source={{ uri: cover.generateUrl(record.coverArt ?? '', { size: 128 }) }}
+                        cacheKey={record.coverArt ? `${record.coverArt}-128x128` : 'empty-128x128'}
+                        size={50}
+                        radius={6}
+                        withShadow={false}
+                    />
+                    <View style={styles.metadata}>
+                        <Title size={14} numberOfLines={1}>{record.title}</Title>
+                        {record.artist && (
+                            <Title size={12} fontFamily="Poppins-Regular" color={colors.text[1]} numberOfLines={1}>
+                                {record.artist}
+                            </Title>
+                        )}
+                        <Title size={11} fontFamily="Poppins-Regular" color={colors.text[2]} numberOfLines={1} style={styles.timestamp}>
+                            {formattedTime}
+                        </Title>
+                    </View>
+                </View>
+            </View>
+        </Pressable>
+    );
+});

--- a/lib/components/PlaybackHistoryTracker.tsx
+++ b/lib/components/PlaybackHistoryTracker.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useOnPlaybackProgressChange } from 'react-native-nitro-player';
+import { useQueue } from '@lib/hooks';
+import { usePlaybackHistory } from '@lib/hooks/usePlaybackHistory';
+
+export interface PlaybackHistoryTrackerProps {
+    children?: React.ReactNode;
+}
+
+
+export function PlaybackHistoryTracker({ children }: PlaybackHistoryTrackerProps) {
+    const { position: playbackPosition } = useOnPlaybackProgressChange();
+    const { nowPlaying } = useQueue();
+    const { addRecord } = usePlaybackHistory();
+    
+    const [hasRecorded, setHasRecorded] = useState(false);
+    const currentTrackIdRef = useRef<string>('');
+
+    useEffect(() => {
+        if (nowPlaying.id !== currentTrackIdRef.current) {
+            currentTrackIdRef.current = nowPlaying.id;
+            setHasRecorded(false);
+        }
+    }, [nowPlaying.id]);
+
+    useEffect(() => {
+
+        if (hasRecorded || !nowPlaying.id) {
+            return;
+        }
+
+        const duration = nowPlaying.duration ?? 0;
+        const threshold = Math.min(30, duration * 0.5);
+
+        if (playbackPosition >= threshold) {
+            addRecord(nowPlaying).catch(error => {
+                console.error('Failed to record playback history:', error);
+            });
+            setHasRecorded(true);
+        }
+    }, [playbackPosition, nowPlaying, hasRecorded, addRecord]);
+
+    return <>{children}</>;
+}

--- a/lib/components/nowPlaying/NowPlayingActions.tsx
+++ b/lib/components/nowPlaying/NowPlayingActions.tsx
@@ -46,7 +46,7 @@ export default function NowPlayingActions() {
                         context: 'nowPlaying'
                     }
                 });
-                if (data.shouldCloseSheet) SheetManager.hide(sheetId);
+                if (data?.shouldCloseSheet) SheetManager.hide(sheetId);
             }} />
         </View>
     )

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -17,3 +17,4 @@ export * from './useSearchHistory';
 export * from './useSearchItemActions';
 export * from './useHomeItemActions';
 export * from './useDownloads';
+export * from './usePlaybackHistory';

--- a/lib/hooks/usePlaybackHistory.ts
+++ b/lib/hooks/usePlaybackHistory.ts
@@ -1,0 +1,129 @@
+import { Child } from '@lib/types/OpenSubsonic';
+import { useSQLiteContext } from 'expo-sqlite';
+import { useCallback } from 'react';
+
+export interface PlaybackHistoryRecord {
+    id: number;
+    trackId: string;
+    title: string;
+    artist?: string;
+    album?: string;
+    coverArt?: string;
+    duration?: number;
+    playedAt: Date;
+}
+
+export interface UsePlaybackHistoryReturn {
+
+    addRecord: (track: Child) => Promise<void>;
+    
+    fetchHistory: (offset?: number, limit?: number) => Promise<PlaybackHistoryRecord[]>;
+    
+    clearHistory: () => Promise<void>;
+    
+    getCount: () => Promise<number>;
+    
+    hasTrack: (trackId: string) => Promise<boolean>;
+}
+
+export function usePlaybackHistory(): UsePlaybackHistoryReturn {
+    const db = useSQLiteContext();
+
+    const addRecord = useCallback(async (track: Child) => {
+        try {
+            await db.runAsync(
+                `INSERT INTO playbackHistory (trackId, title, artist, album, coverArt, duration, playedAt) 
+                 VALUES ($trackId, $title, $artist, $album, $coverArt, $duration, $playedAt)`,
+                {
+                    $trackId: track.id,
+                    $title: track.title,
+                    $artist: track.artist || null,
+                    $album: track.album || null,
+                    $coverArt: track.coverArt || null,
+                    $duration: track.duration || null,
+                    $playedAt: Date.now(),
+                }
+            );
+
+            //maximum 1000 records by deleting oldest records
+            const count = await db.getFirstAsync<{ count: number }>(
+                'SELECT COUNT(*) as count FROM playbackHistory'
+            );
+            
+            if (count && count.count > 1000) {
+                const excessCount = count.count - 1000;
+                await db.runAsync(
+                    `DELETE FROM playbackHistory 
+                     WHERE id IN (
+                         SELECT id FROM playbackHistory 
+                         ORDER BY playedAt ASC 
+                         LIMIT $limit
+                     )`,
+                    { $limit: excessCount }
+                );
+            }
+        } catch (error) {
+            console.error('Failed to add playback history record:', error);
+        }
+    }, [db]);
+
+    const fetchHistory = useCallback(async (offset: number = 0, limit: number = 50): Promise<PlaybackHistoryRecord[]> => {
+        try {
+            const records = await db.getAllAsync<Omit<PlaybackHistoryRecord, 'playedAt'> & { playedAt: number }>(
+                `SELECT id, trackId, title, artist, album, coverArt, duration, playedAt 
+                 FROM playbackHistory 
+                 ORDER BY playedAt DESC 
+                 LIMIT $limit OFFSET $offset`,
+                { $limit: limit, $offset: offset }
+            );
+            return records.map(record => ({
+                ...record,
+                playedAt: new Date(record.playedAt),
+            }));
+        } catch (error) {
+            console.error('Failed to fetch playback history:', error);
+            return [];
+        }
+    }, [db]);
+
+    const clearHistory = useCallback(async () => {
+        try {
+            await db.runAsync('DELETE FROM playbackHistory');
+        } catch (error) {
+            console.error('Failed to clear playback history:', error);
+        }
+    }, [db]);
+
+    const getCount = useCallback(async (): Promise<number> => {
+        try {
+            const result = await db.getFirstAsync<{ count: number }>(
+                'SELECT COUNT(*) as count FROM playbackHistory'
+            );
+            return result?.count || 0;
+        } catch (error) {
+            console.error('Failed to get playback history count:', error);
+            return 0;
+        }
+    }, [db]);
+
+    const hasTrack = useCallback(async (trackId: string): Promise<boolean> => {
+        try {
+            const result = await db.getFirstAsync<{ exists: number }>(
+                'SELECT EXISTS(SELECT 1 FROM playbackHistory WHERE trackId = $trackId) as exists',
+                { $trackId: trackId }
+            );
+            return result?.exists === 1;
+        } catch (error) {
+            console.error('Failed to check if track exists in history:', error);
+            return false;
+        }
+    }, [db]);
+
+    return {
+        addRecord,
+        fetchHistory,
+        clearHistory,
+        getCount,
+        hasTrack,
+    };
+}

--- a/lib/initDatabase.ts
+++ b/lib/initDatabase.ts
@@ -36,4 +36,33 @@ export default async function initDatabase(db: SQLiteDatabase) {
         searchedAt DATETIME DEFAULT CURRENT_TIMESTAMP not null,
         primary key (id)
     )`);
+
+    try {
+        const tableInfo = await db.getAllAsync<{ name: string, type: string }>(
+            `PRAGMA table_info(playbackHistory)`
+        );
+        const playedAtColumn = tableInfo.find(col => col.name === 'playedAt');
+        if (playedAtColumn && playedAtColumn.type === 'DATETIME') {
+            await db.execAsync('DROP TABLE IF EXISTS playbackHistory');
+        }
+    } catch (error) {
+
+    }
+
+    await db.execAsync(`CREATE TABLE IF NOT EXISTS playbackHistory (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        trackId TEXT NOT NULL,
+        title TEXT NOT NULL,
+        artist TEXT,
+        album TEXT,
+        coverArt TEXT,
+        duration INTEGER,
+        playedAt INTEGER NOT NULL
+    )`);
+
+    await db.execAsync(`CREATE INDEX IF NOT EXISTS idx_playbackHistory_playedAt 
+        ON playbackHistory(playedAt DESC)`);
+
+    await db.execAsync(`CREATE INDEX IF NOT EXISTS idx_playbackHistory_trackId 
+        ON playbackHistory(trackId)`);
 }

--- a/lib/sheets/index.tsx
+++ b/lib/sheets/index.tsx
@@ -56,7 +56,7 @@ declare module 'react-native-actions-sheet' {
             payload: {
                 id: string;
                 data?: Child;
-                context?: 'home' | 'playlist' | 'album' | 'nowPlaying' | 'search';
+                context?: 'home' | 'playlist' | 'album' | 'nowPlaying' | 'search' | 'history';
                 contextId?: string;
             },
             returnValue: {

--- a/lib/util/historyHelpers.ts
+++ b/lib/util/historyHelpers.ts
@@ -1,0 +1,70 @@
+import { PlaybackHistoryRecord } from '@lib/hooks/usePlaybackHistory';
+
+export type DateGroup = 'today' | 'yesterday' | 'thisWeek' | 'earlier';
+
+export interface GroupedHistory {
+    today: PlaybackHistoryRecord[];
+    yesterday: PlaybackHistoryRecord[];
+    thisWeek: PlaybackHistoryRecord[];
+    earlier: PlaybackHistoryRecord[];
+}
+
+/**
+ * Groups playback history records by date categories
+ * @param records - Array of playback history records to group
+ * @returns GroupedHistory object with records organized by date
+ */
+export function groupHistoryByDate(records: PlaybackHistoryRecord[]): GroupedHistory {
+    const now = new Date();
+    
+    // Calculate date boundaries
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const yesterdayStart = new Date(todayStart.getTime() - 86400000); // 24 hours in ms
+    const weekStart = new Date(todayStart.getTime() - 7 * 86400000); // 7 days in ms
+    
+    const grouped: GroupedHistory = {
+        today: [],
+        yesterday: [],
+        thisWeek: [],
+        earlier: [],
+    };
+    
+    for (const record of records) {
+        const playedAt = record.playedAt;
+        const playedAtTime = playedAt.getTime();
+        
+        if (playedAtTime >= todayStart.getTime()) {
+            grouped.today.push(record);
+        } else if (playedAtTime >= yesterdayStart.getTime()) {
+            grouped.yesterday.push(record);
+        } else if (playedAtTime >= weekStart.getTime()) {
+            grouped.thisWeek.push(record);
+        } else {
+            grouped.earlier.push(record);
+        }
+    }
+    
+    return grouped;
+}
+
+/**
+ * Formats a playback timestamp into a human-readable string
+ * @param date - The date to format
+ * @returns Human-readable time string (e.g., "2 hours ago", "Yesterday", "Jan 15")
+ */
+export function formatPlaybackTime(date: Date): string {
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+    
+    if (diffMins < 1) return 'Just now';
+    if (diffMins < 60) return `${diffMins} min ago`;
+    if (diffHours < 24) return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
+    if (diffDays === 1) return 'Yesterday';
+    if (diffDays < 7) return `${diffDays} days ago`;
+    
+    // Format as "Jan 15" for older dates
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -4,3 +4,4 @@ export * from './generateSubsonicToken';
 export * from './secondsToTimecode';
 export * from './prependKeysWithDollar';
 export * from './shuffleArray';
+export * from './historyHelpers';

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,8 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+// Add support for .wasm files
+config.resolver.assetExts.push('wasm');
+
+module.exports = config;


### PR DESCRIPTION
- Track songs after 30s or 50% playback threshold
- Store history in SQLite with auto-cleanup (max 1000 records)
- Display history grouped by date (Today/Yesterday/This Week/Earlier)
- Add history screen with infinite scroll and pull-to-refresh
- Add clear history option in settings